### PR TITLE
feat: increase pr_agent timeout_minutes

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   pr_agent_job:
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 10
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Increased the timeout for the `pr_agent_job` in the GitHub Actions workflow from 1 minute to 10 minutes. This enhancement aims to provide more time for the PR agent job to complete its tasks without timing out prematurely.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_agent.yml</strong><dd><code>Increase PR Agent Job Timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr_agent.yml
<li>Increased the timeout for <code>pr_agent_job</code> from 1 minute to 10 minutes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/akhfa/ansible-role-upgrade-all-packages/pull/3/files#diff-fc2b2ed01cad745cb09e9c20e7c91db7f4f1eb9796abb84bbdce7dd0f77dace8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

