### PR TITLE
fix: update apt cache before install aptitude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 2024-03-16
 
+### Fixed
+- Ensured apt cache is updated before installing aptitude on Debian/Ubuntu systems and corrected parameter usage in Ansible tasks.
+
+## 2024-03-16
+
 ### Added
 - Support for Python 3.12 in CI environments.
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,8 +31,9 @@
   block:
     - name: Debian/Ubuntu | Install aptitude is this is a debian/ubuntu system
       ansible.builtin.apt:
-        pkg: aptitude
+        name: aptitude
         state: present
+        update_cache: true
     - name: Debian/Ubuntu | upgrade all packages (Debian)
       ansible.builtin.apt:
         name: '*'


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Ensures the apt cache is updated before attempting to install aptitude on Debian/Ubuntu systems.
- Corrects the parameter from `pkg` to `name` for the aptitude installation task, aligning with Ansible best practices.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.yml</strong><dd><code>Ensure apt cache is updated before installing aptitude</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tasks/main.yml
<li>Changed <code>pkg</code> to <code>name</code> for aptitude installation task.<br> <li> Added <code>update_cache: true</code> to ensure the apt cache is updated before <br>installing aptitude.


</details>
    

  </td>
  <td><a href="https://github.com/akhfa/ansible-role-upgrade-all-packages/pull/6/files#diff-3d0ff1709ca48add100327bb2a468e6c508fb92a159c64c4f99ad1df89d9bdde">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

